### PR TITLE
Check type instead of value

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -81,7 +81,7 @@ serve(
       return new Response(params, { status: 400 });
     }
     const remoteImage = await getRemoteImage(params.image);
-    if (remoteImage === "string") {
+    if (typeof remoteImage === "string") {
       return new Response(remoteImage, { status: 400 });
     }
     const modifiedImage = await modifyImage(remoteImage.buffer, params);


### PR DESCRIPTION
## Why?

`remoteImage` is never strictly equal to the value `"string"`